### PR TITLE
fix(ci): pin danger to last working version 11.2.6

### DIFF
--- a/tools/danger/package-lock.json
+++ b/tools/danger/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "danger": "^11.2.6"
+        "danger": "11.2.6"
       }
     },
     "node_modules/@gitbeaker/core": {

--- a/tools/danger/package.json
+++ b/tools/danger/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/nanlabs/awesome-nan#readme",
   "devDependencies": {
-    "danger": "^11.2.6"
+    "danger": "11.2.6"
   }
 }


### PR DESCRIPTION
danger 13 crashes the shared PR validation workflow (ERR_STREAM_PREMATURE_CLOSE on every GitHub API fetch); danger 11 passes on identical infrastructure. Pins the exact last working version until upstream is resolved. Supersedes the version-bump half of #21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Danger development tool to version 11.2.6 for consistent tooling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->